### PR TITLE
Change default keybinding to `alt + i` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,19 @@ To install this plugin, download zip archive from GitHub releases page. Extract 
 # Future improvement
 - Find a way to detect when the website doesn't allow cross origins.
 - Support more websites.
+
+# Change log
+
+## 0.2.0
+- Update: the keybinding from `Mode + Shift + I` to `Alt + I` ([Issue 4](https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/4)) 
+- Only ouput the app name in the console ([Issue 3](https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/3))
+- Add a min-height (defaults to 16:9 aspect ratio). (Kankaristo).
+- Make sure the iframe can work without the CSS class. (Kankaristo)
+- Fix the bad resizing when using Sliding Panes Plugin ([Issue 1](https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/1)) (Kankaristo)
+- Better user messages and README.md (Kankaristo)
+
+## 0.1.0
+First release
+
+# Thank you
+- [Sami Kankaristo](https://github.com/kankaristo)

--- a/main.ts
+++ b/main.ts
@@ -13,7 +13,7 @@ export default class FormatNotionPlugin extends Plugin {
 			callback: () => this.urlToIframe(),
 			hotkeys: [
 				{
-					modifiers: ["Mod", "Shift"],
+					modifiers: ["Alt"],
 					key: "i",
 				},
 			],

--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,7 @@ import { ConfigureIframeModal } from './configure_iframe_modal';
 
 export default class FormatNotionPlugin extends Plugin {
 	async onload() {
-		console.log(this.app);
+		console.log('Loading obsidian-convert-url-to-iframe');
 		this.addCommand({
 			id: "url-to-iframe",
 			name: "URL to iframe/preview",
@@ -31,7 +31,6 @@ export default class FormatNotionPlugin extends Plugin {
 			const url = updateUrlIfYoutube(selectedText)
 			const modal = new ConfigureIframeModal(this.app, url, editor)
 			modal.open();
-			console.log(modal)
 		} else {
 			new Notice('Select a URL to convert to an iframe.');
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-convert-url-to-iframe",
-  "version": "0.9.7",
+  "version": "0.2.0",
   "description": "Convert an url (ex, youtube) into an iframe (preview)",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## This PR
Address:
- https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/4
- https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/3
- Add a changelog to the Readme

## Test
@kankaristo Can you test the default binding? It doesn't work properly on my end.

The default is not working and is displayed as 
![image](https://user-images.githubusercontent.com/3494000/105493664-fdb2f100-5cb9-11eb-85b6-016d69c906a0.png)

If I reassign to `alt + i` it's working and is displayed as 
![image](https://user-images.githubusercontent.com/3494000/105493731-11f6ee00-5cba-11eb-87f2-2f61003b95f6.png)

It looks the same but the behavior seems different. I'll ask on the Obsidian Discourse. But I'm curious to see if you also have the issue.

