### PR TITLE
always enable full screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Support for 3rd party plugins is enabled in settings (Obsidian > Settings > Thir
 To install this plugin, download zip archive from GitHub releases page. Extract the archive into <vault>/.obsidian/plugins.
 
 # Change log
+## 0.5.0
+- Always allow full screen for the iframe. In the future it will be an option
 
 ## 0.4.0
 - Instead of doing a custom mapping to embed for YouTube, we now rely on the OEmbed standard. Thanks to https://www.npmjs.com/package/oembed-parser 

--- a/src/components/resizable_iframe_container.ts
+++ b/src/components/resizable_iframe_container.ts
@@ -32,7 +32,10 @@ export function createIframeContainerEl(contentEl: HTMLElement, iframeHtml: stri
 	
 	resetToDefaultWidth();
 
-	console.log(iframeHtml, iframe)
+	// Always allow full screen
+	// TODO make it an option
+	iframe.allowFullscreen = true;
+	iframe.allow= 'fullscreen'
 
 	return {
         iframeContainer,

--- a/src/utils/iframe_generator.utils.ts
+++ b/src/utils/iframe_generator.utils.ts
@@ -1,10 +1,10 @@
-import { hasProvider, extract, VideoTypeData, setRequestOptions } from 'oembed-parser'
+import { hasProvider, extract, VideoTypeData} from 'oembed-parser'
 import * as DOMPurify from 'dompurify'
 
 
 
 const buildDefaultIframe = (url: string) => {
-    return `<iframe src=${url} allow="fullscreen" style="height:100%;width:100%; aspect-ratio: 16 / 9;"></iframe>`
+    return `<iframe src=${url} allow="fullscreen" allowfullscreen style="height:100%;width:100%; aspect-ratio: 16 / 9; "></iframe>`
 }
 
 export const getIframeGeneratorFromSanitize = (sanitize: typeof DOMPurify.sanitize) => async (url: string): Promise<string> => {


### PR DESCRIPTION
https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/36

Small improvement to always allow the full screen mode for the iframe. In the future, it will likely become an option in the modal.