### PR TITLE
Enable mobile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To install this plugin, download zip archive from GitHub releases page. Extract 
 # Change log
 ## 0.5.0
 - Always allow full screen for the iframe. In the future it will be an option
+- Enable mobile mode.
 
 ## 0.4.0
 - Instead of doing a custom mapping to embed for YouTube, we now rely on the OEmbed standard. Thanks to https://www.npmjs.com/package/oembed-parser 

--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,5 @@
   "description": "Convert an url (ex, youtube) into an iframe (preview)",
   "author": "Hachez Floran",
   "authorUrl": "https://github.com/FHachez",
-  "isDesktopOnly": true
+  "isDesktopOnly": false
 }


### PR DESCRIPTION
https://github.com/FHachez/obsidian-convert-url-to-iframe/issues/43

Enable the mobile mode, it's hard to test, so it may not be a great experience yet.
The plugin should be functional in mobile size.